### PR TITLE
fix(gui): avoid resolving MusePi.exe as daemon via empty PATH entry

### DIFF
--- a/packages/gui/electron/daemon.cjs
+++ b/packages/gui/electron/daemon.cjs
@@ -108,12 +108,14 @@ function daemonCommand(port) {
 	// shellEnabled); 0 = a random loopback port the daemon persists to
 	// web.port for the compat shell to discover.
 	const webArgs = shellEnabled() ? ["--web-port", "0"] : [];
-	const inPath = (process.env.PATH ?? "")
+	const pathCli = (process.env.PATH ?? "")
 		.split(win ? ";" : ":")
-		.some(dir => fs.existsSync(path.join(dir, win ? "musepi.exe" : "musepi")));
-	if (inPath) {
+		.filter(dir => dir.trim().length > 0)
+		.map(dir => path.resolve(dir, win ? "musepi.exe" : "musepi"))
+		.find(candidate => fs.existsSync(candidate));
+	if (pathCli) {
 		return {
-			program: "musepi",
+			program: pathCli,
 			args: ["serve", "--port", String(port), ...webArgs],
 		};
 	}

--- a/packages/gui/test/daemon-command.test.ts
+++ b/packages/gui/test/daemon-command.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+// daemon.cjs lives outside tsconfig include (electron/) and has no types.
+// @ts-expect-error — untyped CJS module (electron/, outside tsconfig include)
+import { daemonCommand } from "../electron/daemon.cjs";
+
+const originalCwd = process.cwd();
+const originalPath = process.env.PATH;
+const originalPlatform = process.platform;
+const electronProcess = process as typeof process & { resourcesPath?: string };
+const originalResourcesPath = electronProcess.resourcesPath;
+const tempDirs: string[] = [];
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "musepi-daemon-command-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function setWindowsPlatform(): void {
+	Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+}
+
+afterEach(async () => {
+	process.chdir(originalCwd);
+	process.env.PATH = originalPath;
+	Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+	if (originalResourcesPath === undefined) {
+		delete electronProcess.resourcesPath;
+	} else {
+		electronProcess.resourcesPath = originalResourcesPath;
+	}
+	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { force: true, recursive: true })));
+});
+
+describe("daemon.cjs daemonCommand — Windows PATH resolution", () => {
+	it("ignores empty PATH entries instead of resolving musepi.exe from cwd", async () => {
+		const cwd = await tempDir();
+		const resources = await tempDir();
+		const bundled = path.join(resources, "app.asar.unpacked", "vendor", "daemon", "musepi.exe");
+		await fs.writeFile(path.join(cwd, "musepi.exe"), "GUI executable");
+		await fs.mkdir(path.dirname(bundled), { recursive: true });
+		await fs.writeFile(bundled, "bundled daemon");
+		process.chdir(cwd);
+		process.env.PATH = "C:\\foo;;C:\\bar";
+		electronProcess.resourcesPath = resources;
+		setWindowsPlatform();
+
+		expect(daemonCommand(8300).program).toBe(bundled);
+	});
+
+	it("uses the resolved executable for a real PATH CLI", async () => {
+		const cliDir = await tempDir();
+		const cli = path.join(cliDir, "musepi.exe");
+		await fs.writeFile(cli, "CLI executable");
+		process.env.PATH = cliDir;
+		setWindowsPlatform();
+
+		expect(daemonCommand(8300).program).toBe(path.resolve(cli));
+	});
+
+	it("falls back to the bundled daemon when PATH has no CLI", async () => {
+		const resources = await tempDir();
+		const bundled = path.join(resources, "app.asar.unpacked", "vendor", "daemon", "musepi.exe");
+		await fs.mkdir(path.dirname(bundled), { recursive: true });
+		await fs.writeFile(bundled, "bundled daemon");
+		process.env.PATH = "C:\\foo;C:\\bar";
+		electronProcess.resourcesPath = resources;
+		setWindowsPlatform();
+
+		expect(daemonCommand(8300).program).toBe(bundled);
+	});
+});


### PR DESCRIPTION
## Problem

On Windows, an empty PATH entry can be treated as the current working directory by `daemonCommand`'s manual PATH scan. If MusePi's install directory is the working directory, the GUI executable can satisfy the `musepi.exe` existence check.

## Real-world reproduction

PATH contained an empty entry. The equivalent resolver scan produced:

```text
{ i: 87, dir: '', candidate: 'musepi.exe', resolved: 'D:\\MusePi\\musepi.exe' }
```

## Binary identity evidence

`D:\\MusePi\\MusePi.exe` and `D:\\MusePi\\musepi.exe` had the identical SHA256:

`EC7EF70073D6E8AA50DB3599F38EB046320B062D242D072917B884AE05BCB710`

The bundled daemon SHA256 was different:

`8C0DF906267105AB284C9996227E62F44C2E45D7B345F55D5F8616BC2FE1A9FA`

## Observed behavior

The GUI logged:

```text
[daemon] start musepi serve --port 8300
[daemon] child exited 0 null
```

Running the bundled daemon directly successfully listened on `ws://127.0.0.1:8300`. The real bundled daemon also remained running with `detached: true`, `stdio: "ignore"`, and `windowsHide: true`, so those Electron spawn options were independently ruled out.

## Fix

- Ignore empty and whitespace-only PATH entries.
- Resolve each existing PATH CLI candidate to an absolute executable path and execute that exact path.
- Preserve the existing priority: PATH CLI, then bundled daemon, then development checkout.

This is intentionally limited to the Windows daemon-resolution failure caused by empty PATH entries being interpreted relative to the current working directory.

## Tests

Added `packages/gui/test/daemon-command.test.ts`:

- empty PATH entry does not resolve `cwd/musepi.exe` and falls back to the bundled daemon;
- a real PATH CLI remains preferred and is returned as its absolute path;
- bundled fallback is preserved when PATH has no CLI.

Passed:

```text
bun test packages/gui/test/daemon-command.test.ts packages/gui/test/daemon-probe.test.ts packages/gui/test/daemon-shell.test.ts packages/gui/test/daemon-kill.test.ts
# 11 pass, 0 fail

bun run check:ts
bun run check:rs
```

`bun run test` could not complete in this local Windows environment: the default run stopped in Bun's `uv_spawn` with `errno -134`; retrying with `MUSEPI_TEST_CONCURRENCY=1` exposed a missing local `pi_natives` addon. Building that addon was blocked while rustup downloaded the nightly toolchain because the disk reported `os error 112` (no space left). These failures occur before the daemon resolver tests and are unrelated to this change.